### PR TITLE
Align frontend start script with docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ npm run dev
 安装MySQL，创建数据库（如 attendance_db）
 配置 backend/.env 里的数据库连接信息
 可用 Sequelize 自动建表/同步
+```

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "node index.js",
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,7 @@ npm install
 
 ### Compiles and hot-reloads for development
 ```
-npm run serve
+npm run dev
 ```
 
 ### Compiles and minifies for production

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
+    "dev": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint"
   },


### PR DESCRIPTION
## Summary
- add backend dev/start scripts
- rename frontend `serve` script to `dev`
- close bash block in README
- update frontend docs to use `npm run dev`

## Testing
- `npm run lint` *(fails: 'router' is not defined and component name should be multi-word)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686b2b3d1d0c8322ac132540911749d9