### PR TITLE
Fix duplicate export in vue.config.js

### DIFF
--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,8 +1,7 @@
 const { defineConfig } = require('@vue/cli-service')
+
 module.exports = defineConfig({
-  transpileDependencies: true
-})
-module.exports = {
+  transpileDependencies: true,
   devServer: {
     proxy: {
       '/api': {
@@ -12,4 +11,4 @@ module.exports = {
       }
     }
   }
-}
+})


### PR DESCRIPTION
## Summary
- refactor vue.config.js to use a single `module.exports` through `defineConfig`

## Testing
- `npm run lint` *(fails: router is not defined and multi-word component name)*

------
https://chatgpt.com/codex/tasks/task_e_686b2b5f347c83228897dd315896d188