### PR TITLE
Add JWT auth middleware and logout API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,11 @@ npm run dev
 安装MySQL，创建数据库（如 attendance_db）
 配置 backend/.env 里的数据库连接信息
 可用 Sequelize 自动建表/同步
+```
+
+### 2. 认证接口
+
+- `POST /register` 用户注册
+- `POST /login`    登录，返回 JWT
+- `POST /logout`   需要在 `Authorization` 头中携带 `Bearer <token>`，用于登出
+


### PR DESCRIPTION
## Summary
- implement JWT middleware to guard protected routes
- add a POST `/logout` route
- document auth endpoints in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686b2b6a884c8322b1e17f714c0bcdd0