### PR TITLE
Ensure API requests use /api prefix

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,7 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: '/api'
+})
+
+export default api

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -18,7 +18,7 @@
 
 <script setup>
 import { reactive, ref } from 'vue'
-import axios from 'axios'
+import api from '../api'
 
 const form = reactive({
   username: '',
@@ -31,7 +31,7 @@ const onSubmit = async () => {
   error.value = ''
   loading.value = true
   try {
-    const res = await axios.post('http://localhost:3000/login', form)
+    const res = await api.post('/login', form)
     localStorage.setItem('token', res.data.token)
     // 可以根据角色跳转页面，这里简单alert
     alert('登录成功')


### PR DESCRIPTION
## Summary
- centralize axios configuration with `/api` base URL
- update login component to use new API helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b29aaaf2c8322a202c6e7bcde0524